### PR TITLE
Versions dm_control to a specific hash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
                       'termcolor',  # adept_envs dependency
                       'click',  # adept_envs dependency
                       'dm_control' if 'macOS' in platform() else
-                      'dm_control @ git+git://github.com/deepmind/dm_control@master#egg=dm_control',
+                      'dm_control @ git+git://github.com/deepmind/dm_control@ff8a9caac9d845c1e1f669c272294b3355d6d855#egg=dm_control',
                       'mjrl @ git+git://github.com/aravindr93/mjrl@master#egg=mjrl'],
     packages=find_packages(),
     package_data={'d4rl': ['locomotion/assets/*',


### PR DESCRIPTION
I'm not sure this is actually the hash that the benchmark should use, but this is at least before the Mujoco 2.1 upgrade, and so it unbreaks D4RL installation.

Doesn't fix https://github.com/rail-berkeley/d4rl/issues/125 fully since probably all deps should be versioned.